### PR TITLE
feat :sparkles: sends email when is an emergency

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -35,25 +35,6 @@
         "sessionExpiry": ""
     },
     {
-        "id": "1862b367bc6c5f2b",
-        "type": "ui_group",
-        "name": "Garden main parameters",
-        "tab": "53cd983c754bdca0",
-        "order": 1,
-        "disp": true,
-        "width": "12",
-        "collapse": false,
-        "className": ""
-    },
-    {
-        "id": "53cd983c754bdca0",
-        "type": "ui_tab",
-        "name": "Home",
-        "icon": "dashboard",
-        "disabled": false,
-        "hidden": false
-    },
-    {
         "id": "b92b56e2b4f15792",
         "type": "ui_base",
         "theme": {
@@ -151,6 +132,25 @@
         }
     },
     {
+        "id": "53cd983c754bdca0",
+        "type": "ui_tab",
+        "name": "Home",
+        "icon": "dashboard",
+        "disabled": false,
+        "hidden": false
+    },
+    {
+        "id": "1862b367bc6c5f2b",
+        "type": "ui_group",
+        "name": "Garden main parameters",
+        "tab": "53cd983c754bdca0",
+        "order": 1,
+        "disp": true,
+        "width": "12",
+        "collapse": false,
+        "className": ""
+    },
+    {
         "id": "9a847be77c0152f5",
         "type": "mqtt in",
         "z": "7f1f0b300687486f",
@@ -169,7 +169,8 @@
             [
                 "b05749f3bb42398d",
                 "00005aaba021b093",
-                "cfd23472fed9db12"
+                "cfd23472fed9db12",
+                "57dbd8200a17bf76"
             ]
         ]
     },
@@ -361,5 +362,38 @@
         "wires": [
             []
         ]
+    },
+    {
+        "id": "57dbd8200a17bf76",
+        "type": "function",
+        "z": "7f1f0b300687486f",
+        "name": "isAnEmergency",
+        "func": "const MIN_SOIL_HUMIDITY = 20;\nconst MAX_SOIL_HUMIDITY = 60;\nconst NOW = new Date().toISOString();\nconst PLACEHOLDER = \"{{PLACEHOLDER}}\";\n\nconst { soilHumidity } = msg.payload;\nlet lowerOrHigherText;\nlet newMessage = {\n    topic: \"Alerta de Humidade da Horta\",\n    payload: `[${NOW}] Humidade do solo: ${soilHumidity}\\n A humidade do solo da horta está muito ${PLACEHOLDER} dos níveis esperados.`\n}\n\nif (soilHumidity < MIN_SOIL_HUMIDITY) {\n    newMessage.payload = newMessage.payload.replace(PLACEHOLDER, \"abaixo\");\n    return newMessage;\n}\nif (soilHumidity > MAX_SOIL_HUMIDITY) {\n    newMessage.payload = newMessage.payload.replace(PLACEHOLDER, \"acima\");\n    return newMessage;\n}",
+        "outputs": 1,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 880,
+        "y": 280,
+        "wires": [
+            [
+                "50dd4eeba2032c74"
+            ]
+        ]
+    },
+    {
+        "id": "50dd4eeba2032c74",
+        "type": "e-mail",
+        "z": "7f1f0b300687486f",
+        "server": "smtp.office365.com",
+        "port": "587",
+        "secure": false,
+        "tls": false,
+        "name": "rafaelfumegalli@gmail.com",
+        "dname": "",
+        "x": 1200,
+        "y": 280,
+        "wires": []
     }
 ]

--- a/flow_cred.json
+++ b/flow_cred.json
@@ -1,3 +1,7 @@
 {
-    "591bf1f19ad5e29d": {}
+    "591bf1f19ad5e29d": {},
+    "50dd4eeba2032c74": {
+        "userid": "iotgarden@outlook.com",
+        "password": "COLE_A_SENHA_AQUI"
+    }
 }


### PR DESCRIPTION
- No nodo de envio de email, podemos adicionar mais destinatários separando por `,`;
- Ainda no nodo de email, é necessário trocar a senha para a senha real do email criado para ser o remetente. Isso foi feito porque a senha é versionada, como podemos ver no arquivo `flow_cred.json`;
![image](https://user-images.githubusercontent.com/40078545/203303413-022658b5-8f00-42b5-813b-4a18d9a4d82e.png)
